### PR TITLE
Fix autoload behaviour

### DIFF
--- a/wisp-mode.el
+++ b/wisp-mode.el
@@ -23,13 +23,6 @@
   "A major mode for wisp"
   :group 'languages)
 
-;;;###autoload
-(defcustom wisp-mode/file-extension ".wisp"
-  "Wisp file extension."
-  :type 'string
-  :group 'wisp)
-
-;;;###autoload
 (defadvice lisp-eval-region (around lisp-eval-region-flash activate)
   "Flash any calls to lisp-eval-region (and the functions that depend on it, like lisp-eval-defun)."
   (let* ((start (ad-get-arg 0))
@@ -55,8 +48,7 @@ Optional argument CHARS Characters to add to the syntax table."
   (set (make-local-variable 'inferior-lisp-program) "wisp"))
 
 ;;;###autoload
-(when wisp-mode/file-extension
-	(add-to-list 'auto-mode-alist (cons (rx-to-string wisp-mode/file-extension) 'wisp-mode)))
+(add-to-list 'auto-mode-alist (cons "\\.wisp\\'" 'wisp-mode))
 
 ;;;###autoload
 (defun wisp-mode/compile ()


### PR DESCRIPTION
Autoloading the defadvice is not advisable, since it takes effect even if a user chooses not to enable `wisp-mode`.

And autoloading a `defcustom` with the filename extension, then also modifying `auto-mode-alist` in an autoloaded block will not have the desired effect: it is unlikely that custom variables will have been set before the autoloads file has been executed, and hence any user customisation will have no effect. The standard solution - where the file extension is reasonably unambiguous - is to just unconditionally add it to `auto-mode-alist`.

(A good rule of thumb for custom vars is that they should have the desired effect whether they are set before or after the related library has been loaded.)

Cheers,

-Steve
